### PR TITLE
add site config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,13 @@
+baseurl: ""
+url: https://tenthousandsu.com
+
+exclude:
+  # For local development, uncomment `erc721/` to speed up Jekyll builds
+  # when you are not testing the on-site NFT metadata/image
+  # - erc721/
+
+incremental: true
+
+# Uncomment for same-device local use only; livereload can break when testing
+# from other devices on the network, such as a phone.
+# livereload: true


### PR DESCRIPTION
## Description

This is high priority foundational PR for creating a suitable local developer environment.

The main practical issue is local build time. The `erc721/` tree is primarily a production-facing NFT metadata/image endpoint, and in most normal site development work it is not needed at all. When it is included, local Jekyll builds can take minutes; when it is excluded, rebuilds drop to seconds. The config file makes the behavior discoverable and repeatable for excluding it with a single uncommenting, instead of requiring developers to remember a CLI flag.

As a convenience, it also provides standard Jekyll development settings such as incremental rebuilds and optional livereload. Given that livereload is disruptive to mobile testing (prevents my device from ever loading a page), I defaulted it to off. 

The config also establishes the baseline site settings Jekyll expects, including `url`, `baseurl`.
