### PR TITLE
Refactor CSS foundation into shared and page styles

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -5,12 +5,12 @@
   <title>{{ page.title | escape }}</title>
   <link rel="canonical" href="{{ site.url | escape }}{{ page.permalink | escape }}" />
   <link rel="icon" type="image/svg+xml" href="/assets/images/branding/logomark.svg">
-  <link rel="stylesheet" href="/assets/main.css">
+  <link rel="stylesheet" href="/assets/css/main.css">
   <script src="https://cdn.jsdelivr.net/npm/anchor-js@4.3.1/anchor.min.js" integrity="sha256-0WMZ9PF4b2hTF66Eglv/9H5Vwk6lnOG4AbmCJxo96WQ=" crossorigin="anonymous"></script>
 </head>
 <body>
   <header>
-    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg" style="width:348px;height:57px;object-fit:cover;"></div></a>
+    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg"></div></a>
   </header>
 
   <hr>

--- a/assets/css/buy.css
+++ b/assets/css/buy.css
@@ -1,0 +1,8 @@
+#square-number {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+#mint-selected-square {
+  display: none;
+}

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1,0 +1,48 @@
+#wheretogo > div {
+  position: relative;
+  height: 1000px;
+}
+
+#wheretogo #theImage {
+  margin: 0;
+  height: 1000px;
+  width: 1000px;
+}
+
+#position {
+  background: pink;
+  opacity: 0.8;
+  width: 10px;
+  height: 10px;
+  position: absolute;
+  pointer-events: none;
+}
+
+#tooltip {
+  background: rgba(255, 255, 255, 0.8);
+  width: 140px;
+  position: absolute;
+  pointer-events: none;
+  display: none;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  border-radius: 10px;
+  padding: 10px;
+  color: black;
+}
+
+#newly-minted,
+#newly-personalized {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+#newly-minted {
+  margin-bottom: 2em;
+}
+
+#newly-minted > strong,
+#newly-personalized > strong {
+  flex: 1 1 0;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,20 +1,31 @@
 /* normalize.css v8.0.1 + Typebase.less v0.1.0 | MIT License | compress csso | add .lead **/
 html{line-height:1.15;-webkit-text-size-adjust:100%;font-family:serif;font-size:137.5%;-webkit-font-smoothing:antialiased}body{margin:0}details,main{display:block}h1{font-size:2em;margin:.67em 0}hr{box-sizing:content-box;height:0;overflow:visible}code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}a{background-color:transparent}abbr[title]{border-bottom:none;text-decoration:underline dotted}b,strong{font-weight:bolder}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}img{border-style:none}button,input,optgroup,select,textarea{font-family:inherit;font-size:100%;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{padding:.35em .75em .625em}legend{color:inherit;display:table;max-width:100%;white-space:normal}progress{vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio],legend{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}[hidden],template{display:none}p{margin-bottom:0}ol,p,table,ul{margin-top:1.5rem}ol,ul{margin-bottom:1.5rem}blockquote,ol li,p,ul li{line-height:1.5rem}ol ol,ol ul,ul ol,ul ul{margin-top:0;margin-bottom:0}blockquote{margin-top:1.5rem;margin-bottom:1.5rem}h1,h2,h3,h4,h5,h6{font-family:sans-serif;margin-bottom:0}h1,h2{font-size:4.242rem;line-height:4.5rem;margin-top:3rem}h3,h4,h5,h6{margin-top:1.5rem;line-height:1.5rem}h2{font-size:2.828rem;line-height:3rem}.lead,h3{font-size:1.414rem}h4{font-size:.707rem}h5{font-size:.4713333333333333rem}h6{font-size:.3535rem}table{border-spacing:0;border-collapse:collapse}table td,table th{padding:0;line-height:33px}code{vertical-align:bottom}.hug{margin-top:0}
 
-/* Overrides ******************************************************************/
+:root {
+  --color-primary: #2d3c96;
+  --color-secondary: #d53392;
+  --color-accent: #ffd700;
+  --bg-gradient: linear-gradient(to bottom right, var(--color-primary), var(--color-secondary));
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --max-width-content: 1004px;
+  --logo-width: 348px;
+  --logo-height: 57px;
+  --radius-md: 0.5rem;
+  --shadow-strong: 4px 6px 4px rgba(255, 255, 255, 0.2);
+  --shadow-hover: 3px 6px 10px #999;
+  --shadow-active: 1px 4px 10px #555;
+}
+
 html {
-  /*  font-family: "Helvetica Neue", sans-serif;*/
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: var(--font-sans);
   font-size: 115%;
   -webkit-font-smoothing: antialiased;
 }
 
-/* Application ****************************************************************/
-
 body {
-  background-color: #2d3c96;
-  background-image: linear-gradient(to bottom right, #2d3c96, #d53392);
-  color: #ffd700;
+  background-color: var(--color-primary);
+  background-image: var(--bg-gradient);
+  color: var(--color-accent);
   min-height: 100vh;
   padding-left: 2px;
   padding-right: 2px;
@@ -27,34 +38,40 @@ header {
   justify-content: space-between;
   align-items: center;
   box-sizing: border-box;
-  min-width: 1004px;
+  min-width: var(--max-width-content);
 }
 
 header > * {
   flex-grow: 0;
-  text-align: center
+  text-align: center;
+}
+
+#logo img {
+  width: var(--logo-width);
+  height: var(--logo-height);
+  object-fit: cover;
 }
 
 .btn {
   background: none;
-  border-radius: 0.5rem;
-  border: 2px solid #ffd700;
-  box-shadow: 4px 6px 4px rgba(255, 255, 255, 0.2);
-  color: #ffd700;
+  border-radius: var(--radius-md);
+  border: 2px solid var(--color-accent);
+  box-shadow: var(--shadow-strong);
+  color: var(--color-accent);
   padding: 10px;
   text-decoration: none;
   cursor: pointer;
 }
 
 .btn:hover {
-  box-shadow: 3px 6px 10px #999;
+  box-shadow: var(--shadow-hover);
 }
 
 .btn:active {
   position: relative;
   left: 2px;
   top: 2px;
-  box-shadow: 1px 4px 10px #555;
+  box-shadow: var(--shadow-active);
 }
 
 .btn-lg {
@@ -72,10 +89,13 @@ input[type="number"] {
   font-size: 115%;
 }
 
+#square-number {
+  width: 7em;
+}
+
 article {
   margin: 1rem auto;
-  width: 1004px;
-
+  width: var(--max-width-content);
 }
 
 footer {
@@ -86,24 +106,14 @@ footer {
 
 hr {
   border: none;
-  border-top: 2rem solid rgba(0,0,0,0.2);
-  border-color: linear-gradient(135deg, rgba(0,0,0,0) 0%,rgba(0,0,0,0.2) 100%);
+  border-top: 2rem solid rgba(0, 0, 0, 0.2);
+  border-color: linear-gradient(135deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.2) 100%);
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
 
-#tooltip {
-  background:rgba(255,255,255,0.8);
-  width:140px;
-  position:absolute;
-  pointer-events:none;
-  display:none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  font-size: 12px;
-  border-radius: 10px;
-  padding:10px;
-}
-
-a:link, a:visited, a:active {
-  color: #ffd700;
+a:link,
+a:visited,
+a:active {
+  color: var(--color-accent);
 }

--- a/assets/css/personalize-batch.css
+++ b/assets/css/personalize-batch.css
@@ -1,0 +1,8 @@
+#top-left-square-number {
+  width: 7em;
+}
+
+#preflight-output {
+  width: 100%;
+  height: 10em;
+}

--- a/assets/css/personalize.css
+++ b/assets/css/personalize.css
@@ -1,0 +1,5 @@
+#image-preview {
+  width: 0;
+  height: 0;
+  image-rendering: pixelated;
+}

--- a/assets/css/square.css
+++ b/assets/css/square.css
@@ -1,0 +1,16 @@
+.square-location-map {
+  position: relative;
+  height: 1000px;
+  zoom: 0.5;
+}
+
+#theImage {
+  height: 1000px;
+  width: 1000px;
+}
+
+#arrow {
+  height: 100px;
+  width: 100px;
+  position: absolute;
+}

--- a/buy.html
+++ b/buy.html
@@ -6,18 +6,13 @@
   <title>Su Squares, mint a square</title>
   <link rel="canonical" href="https://tenthousandsu.com/buy" />
   <link rel="icon" type="image/svg+xml" href="/assets/images/branding/logomark.svg">
-  <link rel="stylesheet" href="assets/main.css">
-  <style>
-    #square-number {
-      margin-top: 0.5em;
-      margin-bottom: 0.5em;
-    }
-  </style>
+  <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/buy.css">
 </head>
 
 <body>
   <header>
-    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg" style="width:348px;height:57px;object-fit: cover;"
+    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg"
         alt="Su Squares logo"></a>
     <button id="connect-wallet" class="btn">Connect wallet</button>
   </header>
@@ -31,12 +26,12 @@
       <h2>Which Square would you like?</h2>
       <form>
         <p><strong>Square number</strong> (between 1 and 10,000)</p>
-        <input id="square-number" type=number min=1 max=10000 required style="width:7em">
+        <input id="square-number" type=number min=1 max=10000 required>
       </form>
       <button id="select-square" type="button" class="btn btn-lg">Select Square</button>
     </div>
 
-    <div id="mint-selected-square" style="display:none">
+    <div id="mint-selected-square">
       <p>Please connect your wallet using the button above and then click mint below.</p>
       <button id="mint" type="button" class="btn btn-lg">Mint Square</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,12 +7,13 @@
   <meta name="description" content="The first ERC-721 NFT. Cute squares you own and personalize.">
   <link rel="canonical" href="https://tenthousandsu.com" />
   <link rel="icon" type="image/svg+xml" href="/assets/images/branding/logomark.svg">
-  <link rel="stylesheet" href="assets/main.css?20210926">
+  <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/index.css">
 </head>
 
 <body>
   <header>
-    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg" style="width:348px;height:57px;object-fit: cover;"
+    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg"
         alt="Su Squares logo"></a>
     <span>
       The first ERC-721 NFT
@@ -41,24 +42,22 @@
   <article>
     <p>Click below to mint an available Su Square (0.5 ETH).</p>
     <a id="wheretogo" href="#" target="_blank">
-      <div style="position:relative;height:1000px">
-        <img id="theImage" src="build/wholeSquare.webp" alt="All Su Squares"
-          style="margin:0; height:1000px; width:1000px">
-        <div id="position"
-          style="background:pink;opacity:0.8;width:10px;height:10px;;position:absolute;pointer-events:none">
+      <div>
+        <img id="theImage" src="build/wholeSquare.webp" alt="All Su Squares">
+        <div id="position">
         </div>
-        <div id="tooltip" style="color:black"></div>
+        <div id="tooltip"></div>
         <div id="electric-fence"></div>
       </div>
     </a>
   </article>
 
   <article>
-    <section id="newly-minted" style="display:flex; align-items: center; width: 100%; margin-bottom: 2em">
-      <strong style="flex: 1 1 0">Newly minted</strong>
+    <section id="newly-minted">
+      <strong>Newly minted</strong>
     </section>
-    <section id="newly-personalized" style="display:flex; align-items: center; width: 100%">
-      <strong style="flex: 1 1 0">Latest personalized</strong>
+    <section id="newly-personalized">
+      <strong>Latest personalized</strong>
     </section>
   </article>
 

--- a/personalize-batch.html
+++ b/personalize-batch.html
@@ -6,12 +6,13 @@
   <title>Su Squares, personalize batch</title>
   <link rel="canonical" href="https://tenthousandsu.com/personalize-batch" />
   <link rel="icon" type="image/svg+xml" href="/assets/images/branding/logomark.svg">
-  <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/personalize-batch.css">
 </head>
 
 <body>
   <header>
-    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg" style="width:348px;height:57px;object-fit: cover;"
+    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg"
         alt="Su Squares logo"></a>
     <button id="connect-wallet" class="btn">Connect wallet</button>
   </header>
@@ -32,7 +33,7 @@
     <h2>Select top-left Square</h2>
     <p>Which Square will be the topmost and leftmost Square you will personalize?</p>
     <p>
-      <input id="top-left-square-number" type=number min=1 max=10000 required style="width:7em">
+      <input id="top-left-square-number" type=number min=1 max=10000 required>
     </p>
 
     <h2>Enter title</h2>
@@ -71,7 +72,7 @@
     <p>
       <button id="preflight" class="btn">Preflight</button>
     </p>
-    <textarea id="preflight-output" style="width:100%;height:10em"></textarea>
+    <textarea id="preflight-output"></textarea>
     <p>
       To manually edit individual Squares, copy/paste to a spreadsheet, edit, and then copy/paste back here. If you
       would like to personalize a non-rectangular area, delete any rows that are not needed.

--- a/personalize.html
+++ b/personalize.html
@@ -6,12 +6,13 @@
   <title>Su Squares, personalize</title>
   <link rel="canonical" href="https://tenthousandsu.com/personalize" />
   <link rel="icon" type="image/svg+xml" href="/assets/images/branding/logomark.svg">
-  <link rel="stylesheet" href="assets/main.css">
+  <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/personalize.css">
 </head>
 
 <body>
   <header>
-    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg" style="width:348px;height:57px;object-fit: cover;"
+    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg"
         alt="Su Squares logo"></a>
     <button id="connect-wallet" class="btn">Connect wallet</button>
   </header>
@@ -33,7 +34,7 @@
     <h2>Select a Square</h2>
     <p>Which Square will you personalize?</p>
     <p>
-      <input id="square-number" type=number min=1 max=10000 required style="width:7em">
+      <input id="square-number" type=number min=1 max=10000 required>
     </p>
 
     <h2>Enter title</h2>
@@ -60,7 +61,7 @@
       Image status: <span id="image-status">no image selected</span>
     </p>
     <p>
-      <canvas id="image-preview" style="width:0;height:0;image-rendering:pixelated;"></canvas>
+      <canvas id="image-preview"></canvas>
     </p>
 
     <h2>Personalize</h2>

--- a/square.html
+++ b/square.html
@@ -6,12 +6,13 @@
   <title>Su Squares, cute squares you own and personalize</title>
   <meta name="description" content="The first ERC-721 NFT. Cute squares you own and personalize.">
   <link rel="icon" type="image/svg+xml" href="/assets/images/branding/logomark.svg">
-  <link rel="stylesheet" href="assets/main.css?20210926">
+  <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/square.css">
 </head>
 
 <body>
   <header>
-    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg" style="width:348px;height:57px;object-fit: cover;"
+    <a id="logo" href="/"><img src="/assets/images/branding/logo-su-squares.svg"
         alt="Su Squares logo"></a>
     <span>
       The first ERC-721 NFT
@@ -51,9 +52,9 @@
     </dl>
 
     <h2>Location</h2>
-    <div style="position:relative;height:1000px; zoom: 0.5">
-      <img id="theImage" src="build/wholeSquare.webp" alt="All Su Squares" style="height:1000px; width:1000px">
-      <img id="arrow" src="/assets/images/billboard/dr.png" alt="Location" style="height:100px; width:100px; position:absolute">
+    <div class="square-location-map">
+      <img id="theImage" src="build/wholeSquare.webp" alt="All Su Squares">
+      <img id="arrow" src="/assets/images/billboard/dr.png" alt="Location">
     </div>
 
     <h2>Emojified</h2>


### PR DESCRIPTION
## Description

Refactor the site CSS foundation by creating a dedicated `assets/css/` folder and moving styles into explicit shared and page-level paths without intentionally changing the visual design.

Split the old monolithic stylesheet into a shared base at `assets/css/main.css` plus dedicated page stylesheets. Update page heads to load the new paths and move obvious repeated static inline styles into CSS.

Also do a few small follow-up chores: add a named secondary gradient color, deduplicate the shared `#square-number` width rule, and replace the fragile square-page structural selector with an explicit class.