### PR TITLE
Make homepage billboard mobile and touch-friendly

### DIFF
--- a/assets/js/billboard/panzoom.js
+++ b/assets/js/billboard/panzoom.js
@@ -1,0 +1,224 @@
+(function () {
+  "use strict";
+
+  function isTouchDevice() {
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  }
+
+  function create(wrapper, options) {
+    const settings = options || {};
+    const minScale = settings.minScale || 1;
+    const maxScale = settings.maxScale || 6;
+    const onZoomChange = settings.onZoomChange;
+
+    if (!wrapper || !isTouchDevice()) {
+      return {
+        screenToCanvas: function (clientX, clientY) {
+          if (!wrapper) return { x: clientX, y: clientY };
+          const rect = wrapper.getBoundingClientRect();
+          return { x: clientX - rect.left, y: clientY - rect.top };
+        },
+        reset: function () { },
+        destroy: function () { },
+        hasPanned: function () { return false; },
+        isActive: false,
+        scale: 1
+      };
+    }
+
+    let scale = 1;
+    let translateX = 0;
+    let translateY = 0;
+    let initialTouches = null;
+    let initialScale = 1;
+    let initialTranslateX = 0;
+    let initialTranslateY = 0;
+    let didPan = false;
+    let hasEverPinched = false;
+    let wasZoomed = false;
+
+    function notifyZoomChange() {
+      const isZoomed = scale !== 1 || translateX !== 0 || translateY !== 0;
+      if (isZoomed !== wasZoomed) {
+        wasZoomed = isZoomed;
+        if (typeof onZoomChange === "function") {
+          onZoomChange(isZoomed);
+        }
+      }
+    }
+
+    function getViewport() {
+      return wrapper.parentElement || wrapper;
+    }
+
+    function getOriginalWidth() {
+      return wrapper.offsetWidth || wrapper.clientWidth || 0;
+    }
+
+    function getOriginalHeight() {
+      return wrapper.offsetHeight || wrapper.clientHeight || 0;
+    }
+
+    function clamp(value, min, max) {
+      return Math.min(Math.max(value, min), max);
+    }
+
+    function getDistance(touch1, touch2) {
+      const dx = touch2.clientX - touch1.clientX;
+      const dy = touch2.clientY - touch1.clientY;
+      return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    function getMidpoint(touch1, touch2) {
+      return {
+        x: (touch1.clientX + touch2.clientX) / 2,
+        y: (touch1.clientY + touch2.clientY) / 2
+      };
+    }
+
+    function applyTransform() {
+      wrapper.style.transform = scale === 1 && translateX === 0 && translateY === 0
+        ? ""
+        : "translate(" + translateX + "px, " + translateY + "px) scale(" + scale + ")";
+      notifyZoomChange();
+    }
+
+    function constrainBounds() {
+      const originalWidth = getOriginalWidth();
+      const originalHeight = getOriginalHeight();
+      const scaledWidth = originalWidth * scale;
+      const scaledHeight = originalHeight * scale;
+      const minVisible = 0.2;
+
+      const minX = originalWidth * minVisible - scaledWidth;
+      const maxX = originalWidth * (1 - minVisible);
+      const minY = originalHeight * minVisible - scaledHeight;
+      const maxY = originalHeight * (1 - minVisible);
+
+      translateX = clamp(translateX, minX, maxX);
+      translateY = clamp(translateY, minY, maxY);
+    }
+
+    function handleTouchStart(event) {
+      if (event.touches.length === 1 || event.touches.length === 2) {
+        initialTouches = Array.from(event.touches);
+        initialScale = scale;
+        initialTranslateX = translateX;
+        initialTranslateY = translateY;
+        didPan = false;
+      }
+    }
+
+    function handleTouchMove(event) {
+      if (!initialTouches) return;
+
+      if (event.touches.length === 2 && initialTouches.length === 2) {
+        event.preventDefault();
+        didPan = true;
+        hasEverPinched = true;
+
+        const currentDistance = getDistance(event.touches[0], event.touches[1]);
+        const initialDistance = getDistance(initialTouches[0], initialTouches[1]);
+        const scaleRatio = currentDistance / initialDistance;
+        const newScale = clamp(initialScale * scaleRatio, minScale, maxScale);
+
+        const viewportRect = getViewport().getBoundingClientRect();
+        const midpoint = getMidpoint(event.touches[0], event.touches[1]);
+        const screenX = midpoint.x - viewportRect.left;
+        const screenY = midpoint.y - viewportRect.top;
+
+        const canvasX = (screenX - initialTranslateX) / initialScale;
+        const canvasY = (screenY - initialTranslateY) / initialScale;
+
+        translateX = screenX - canvasX * newScale;
+        translateY = screenY - canvasY * newScale;
+        scale = newScale;
+
+        constrainBounds();
+        applyTransform();
+      } else if (event.touches.length === 1 && hasEverPinched) {
+        event.preventDefault();
+        didPan = true;
+
+        const deltaX = event.touches[0].clientX - initialTouches[0].clientX;
+        const deltaY = event.touches[0].clientY - initialTouches[0].clientY;
+
+        translateX = initialTranslateX + deltaX;
+        translateY = initialTranslateY + deltaY;
+
+        constrainBounds();
+        applyTransform();
+      }
+    }
+
+    function handleTouchEnd(event) {
+      if (event.touches.length === 0) {
+        initialTouches = null;
+      } else if (event.touches.length === 1) {
+        initialTouches = Array.from(event.touches);
+        initialScale = scale;
+        initialTranslateX = translateX;
+        initialTranslateY = translateY;
+      }
+    }
+
+    function screenToCanvas(clientX, clientY) {
+      const viewportRect = getViewport().getBoundingClientRect();
+      const screenX = clientX - viewportRect.left;
+      const screenY = clientY - viewportRect.top;
+
+      return {
+        x: (screenX - translateX) / scale,
+        y: (screenY - translateY) / scale
+      };
+    }
+
+    function canvasToScreen(x, y) {
+      return {
+        x: x * scale + translateX,
+        y: y * scale + translateY
+      };
+    }
+
+    function reset() {
+      scale = 1;
+      translateX = 0;
+      translateY = 0;
+      initialTouches = null;
+      didPan = false;
+      hasEverPinched = false;
+      wrapper.style.transform = "";
+      notifyZoomChange();
+    }
+
+    function destroy() {
+      wrapper.removeEventListener("touchstart", handleTouchStart);
+      wrapper.removeEventListener("touchmove", handleTouchMove);
+      wrapper.removeEventListener("touchend", handleTouchEnd);
+      wrapper.removeEventListener("touchcancel", handleTouchEnd);
+      reset();
+    }
+
+    wrapper.addEventListener("touchstart", handleTouchStart, { passive: true });
+    wrapper.addEventListener("touchmove", handleTouchMove, { passive: false });
+    wrapper.addEventListener("touchend", handleTouchEnd, { passive: true });
+    wrapper.addEventListener("touchcancel", handleTouchEnd, { passive: true });
+
+    return {
+      screenToCanvas: screenToCanvas,
+      canvasToScreen: canvasToScreen,
+      hasPanned: function () { return didPan; },
+      reset: reset,
+      destroy: destroy,
+      isActive: true,
+      get scale() {
+        return scale;
+      }
+    };
+  }
+
+  window.SuBillboardPanZoom = {
+    create: create,
+    isTouchDevice: isTouchDevice
+  };
+}());

--- a/assets/js/billboard/touch-ui.js
+++ b/assets/js/billboard/touch-ui.js
@@ -1,0 +1,98 @@
+(function () {
+  "use strict";
+
+  const DEFAULT_HINT_TEXT = "Pinch to zoom, drag to pan, double tap Squares to activate";
+  const DEFAULT_RESET_TEXT = "Reset zoom";
+
+  function isTouchDevice() {
+    if (window.SuBillboardPanZoom && typeof window.SuBillboardPanZoom.isTouchDevice === "function") {
+      return window.SuBillboardPanZoom.isTouchDevice();
+    }
+
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  }
+
+  function attach(options) {
+    const settings = options || {};
+    const wrapper = settings.wrapper;
+    const uiMount = settings.uiMount;
+    const onReset = settings.onReset;
+    const hintText = settings.hintText || DEFAULT_HINT_TEXT;
+    const resetText = settings.resetText || DEFAULT_RESET_TEXT;
+
+    if (!wrapper || !uiMount || !isTouchDevice()) {
+      return {
+        onZoomChange: function () { },
+        restore: function () { },
+        destroy: function () { },
+        elements: { hint: null, resetButton: null }
+      };
+    }
+
+    let isZoomed = false;
+    let hasPanZoomStarted = false;
+
+    const hint = document.createElement("div");
+    hint.className = "map-panzoom-hint";
+    hint.textContent = hintText;
+    hint.setAttribute("aria-hidden", "true");
+
+    const resetButton = document.createElement("button");
+    resetButton.type = "button";
+    resetButton.className = "map-panzoom-reset";
+    resetButton.textContent = resetText;
+
+    function sync() {
+      const showOverlay = hasPanZoomStarted || isZoomed;
+      hint.classList.toggle("is-hidden", showOverlay);
+      resetButton.classList.toggle("is-visible", showOverlay);
+    }
+
+    function handleTouchMove(event) {
+      if (!hasPanZoomStarted && event.touches.length >= 2) {
+        hasPanZoomStarted = true;
+        sync();
+      }
+    }
+
+    function handleResetClick() {
+      hasPanZoomStarted = false;
+      isZoomed = false;
+      if (typeof onReset === "function") {
+        onReset();
+      }
+      sync();
+    }
+
+    wrapper.appendChild(hint);
+    uiMount.appendChild(resetButton);
+    wrapper.addEventListener("touchmove", handleTouchMove, { passive: true });
+    resetButton.addEventListener("click", handleResetClick);
+    sync();
+
+    return {
+      onZoomChange: function (nextZoomed) {
+        isZoomed = Boolean(nextZoomed);
+        sync();
+      },
+      restore: function () {
+        hasPanZoomStarted = false;
+        isZoomed = false;
+        sync();
+      },
+      destroy: function () {
+        wrapper.removeEventListener("touchmove", handleTouchMove);
+        resetButton.removeEventListener("click", handleResetClick);
+        hint.remove();
+        resetButton.remove();
+      },
+      elements: { hint: hint, resetButton: resetButton }
+    };
+  }
+
+  window.SuBillboardTouchUi = {
+    attach: attach,
+    DEFAULT_HINT_TEXT: DEFAULT_HINT_TEXT,
+    DEFAULT_RESET_TEXT: DEFAULT_RESET_TEXT
+  };
+}());

--- a/assets/main.css
+++ b/assets/main.css
@@ -260,18 +260,28 @@ a:active {
   width: 100%;
   max-width: 1000px;
   margin: 0 auto;
+  position: relative;
 }
 
 .map-container {
   width: 100%;
   display: block;
   text-decoration: none;
+  overflow: hidden;
 }
 
 .map-wrapper {
   position: relative;
   width: 100%;
   aspect-ratio: 1 / 1;
+  overflow: hidden;
+}
+
+.map-stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-origin: 0 0;
 }
 
 .map-image {
@@ -279,6 +289,8 @@ a:active {
   height: 100%;
   display: block;
   image-rendering: pixelated;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .map-position {
@@ -287,15 +299,128 @@ a:active {
   width: 10px;
   height: 10px;
   position: absolute;
+  box-sizing: border-box;
   pointer-events: none;
   display: none;
   z-index: 10;
+}
+
+.map-stage--touch {
+  touch-action: none;
+  will-change: transform;
+}
+
+.map-shell--touch .map-position {
+  background: rgba(74, 163, 255, 0.06);
+  border: 2px solid rgba(132, 203, 255, 0.9);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.55),
+    inset 0 0 10px rgba(74, 163, 255, 0.35),
+    0 0 10px rgba(74, 163, 255, 0.55),
+    0 0 18px rgba(74, 163, 255, 0.3);
+  filter: drop-shadow(0 0 8px rgba(74, 163, 255, 0.55));
+  opacity: 1;
+  transform-origin: center center;
+  animation: map-position-touch-pulse 1.2s ease-in-out infinite;
 }
 
 .map-fence {
   position: absolute;
   inset: 0;
   pointer-events: none;
+}
+
+.map-stage .map-tooltip {
+  --map-tooltip-base-scale: 1;
+  transform: scale(var(--map-tooltip-base-scale));
+  transform-origin: top left;
+  z-index: 20;
+}
+
+@keyframes map-position-touch-pulse {
+  0%,
+  100% {
+    background: rgba(74, 163, 255, 0.04);
+    border-color: rgba(74, 163, 255, 0.68);
+    transform: scale(0.96);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.18),
+      inset 0 0 6px rgba(74, 163, 255, 0.16),
+      0 0 6px rgba(74, 163, 255, 0.22),
+      0 0 12px rgba(74, 163, 255, 0.1);
+    filter: drop-shadow(0 0 5px rgba(74, 163, 255, 0.18));
+  }
+
+  50% {
+    background: rgba(74, 163, 255, 0.1);
+    border-color: rgba(132, 203, 255, 1);
+    transform: scale(1.12);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.9),
+      inset 0 0 12px rgba(74, 163, 255, 0.55),
+      0 0 16px rgba(74, 163, 255, 1),
+      0 0 30px rgba(74, 163, 255, 0.82),
+      0 0 46px rgba(74, 163, 255, 0.46);
+    filter: drop-shadow(0 0 14px rgba(74, 163, 255, 0.9));
+  }
+}
+
+.map-panzoom-hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 15;
+  width: min(80%, 420px);
+  max-width: 80%;
+  padding: 2.4vw 3.2vw;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.75);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+  color: #ffd700;
+  font-size: 3.7vw;
+  font-weight: 600;
+  line-height: 1.35;
+  text-align: center;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.map-panzoom-hint.is-hidden {
+  opacity: 0;
+}
+
+.map-panzoom-reset {
+  position: absolute;
+  left: 50%;
+  bottom: 0.35rem;
+  z-index: 15;
+  margin: 0;
+  padding: 2vw 3.7vw;
+  background: rgba(0, 0, 0, 0.78);
+  border: 2px solid #ffd700;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+  transform: translateX(-50%);
+  display: block;
+  cursor: pointer;
+  font-size: 3.3vw;
+  color: #ffd700;
+  opacity: 1;
+  pointer-events: none;
+}
+
+.map-panzoom-reset.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.map-panzoom-reset:not(.is-visible) {
+  opacity: 0;
+}
+
+.map-panzoom-reset:hover {
+  background: rgba(0, 0, 0, 0.9);
 }
 
 .newly-feed {
@@ -694,6 +819,18 @@ a:active {
 
   .map-tooltip {
     min-width: 0;
+  }
+}
+
+@media (min-width: 701px) {
+  .map-panzoom-hint {
+    padding: 0.55rem 0.8rem;
+    font-size: 1rem;
+  }
+
+  .map-panzoom-reset {
+    padding: 0.45rem 0.85rem;
+    font-size: 0.9rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -45,10 +45,12 @@ title: "Su Squares, cute squares you own and personalize"
     <div class="map-shell">
       <a id="wheretogo" class="map-container" href="#" target="_blank">
         <div class="map-wrapper">
-          <img id="theImage" class="map-image" src="/build/wholeSquare.webp" alt="All Su Squares">
-          <div id="position" class="map-position"></div>
-          <div id="tooltip" class="map-tooltip"></div>
-          <div id="electric-fence" class="map-fence"></div>
+          <div id="map-stage" class="map-stage">
+            <img id="theImage" class="map-image" src="/build/wholeSquare.webp" alt="All Su Squares">
+            <div id="position" class="map-position"></div>
+            <div id="tooltip" class="map-tooltip"></div>
+            <div id="electric-fence" class="map-fence"></div>
+          </div>
         </div>
       </a>
     </div>
@@ -75,21 +77,141 @@ title: "Su Squares, cute squares you own and personalize"
       United States.
     </small>
   </footer>
+  <script src="/assets/js/billboard/panzoom.js"></script>
+  <script src="/assets/js/billboard/touch-ui.js"></script>
   <script>
     let positionSquareNumber = 1;
     var squarePersonalizations = [];
     var squareExtra = [];
+    const GRID_DIMENSION = 100;
+    const DOUBLE_TAP_WINDOW_MS = 1200;
+    const SUPPRESS_CLICK_WINDOW_MS = 1000;
+    const TAP_MOVE_TOLERANCE_PX = 12;
+    const TAP_MAX_DURATION_MS = 700;
+    const theImage = document.getElementById("theImage");
+    const mapWrapper = document.querySelector(".map-wrapper");
+    const mapStage = document.getElementById("map-stage");
+    const mapShell = document.querySelector(".map-shell");
+    const whereToGoAnchor = document.getElementById("wheretogo");
+    const isTouchBillboard = Boolean(
+      window.SuBillboardPanZoom &&
+      typeof window.SuBillboardPanZoom.isTouchDevice === "function" &&
+      window.SuBillboardPanZoom.isTouchDevice()
+    );
+    let panZoom = null;
+    let billboardTouchUi = null;
+    let pendingTouchSquare = null;
+    let pendingTouchAt = 0;
+    let suppressClickUntil = 0;
+    let touchStartX = null;
+    let touchStartY = null;
+    let touchStartAt = 0;
+    let touchTapReady = false;
 
     // Animate the electric fence
     let fence = new Set();
     let litUpEdge = new Set();
     let wasEverLitUp = new Set();
-    const GRID_DIMENSION = 100;
+
+    if (isTouchBillboard) {
+      mapShell.classList.add("map-shell--touch");
+      mapStage.classList.add("map-stage--touch");
+    }
+
+    if (window.SuBillboardPanZoom && typeof window.SuBillboardPanZoom.create === "function") {
+      panZoom = window.SuBillboardPanZoom.create(mapStage, {
+        minScale: 1,
+        maxScale: 6,
+        onZoomChange(isZoomed) {
+          if (billboardTouchUi && typeof billboardTouchUi.onZoomChange === "function") {
+            billboardTouchUi.onZoomChange(isZoomed);
+          }
+        }
+      });
+    }
+
+    if (panZoom && panZoom.isActive && window.SuBillboardTouchUi && typeof window.SuBillboardTouchUi.attach === "function") {
+      billboardTouchUi = window.SuBillboardTouchUi.attach({
+        wrapper: mapWrapper,
+        uiMount: mapShell,
+        hintText: "Pinch to zoom, drag to pan, double tap Squares to activate",
+        resetText: "Reset zoom",
+        onReset() {
+          panZoom.reset();
+          pendingTouchSquare = null;
+          pendingTouchAt = 0;
+          touchTapReady = false;
+        }
+      });
+    }
 
     function getMapMetrics() {
-      const wrapper = document.querySelector(".map-wrapper");
-      const cellSize = wrapper ? wrapper.getBoundingClientRect().width / GRID_DIMENSION : 10;
-      return { wrapper, cellSize: cellSize || 10 };
+      const viewport = mapWrapper;
+      const stage = mapStage;
+      const viewportRect = viewport ? viewport.getBoundingClientRect() : null;
+      const cellSize = viewportRect ? viewportRect.width / GRID_DIMENSION : 10;
+      return { viewport, stage, cellSize: cellSize || 10 };
+    }
+
+    function getSquareFromPoint(clientX, clientY) {
+      let x;
+      let y;
+      let effectiveWidth;
+
+      if (panZoom && panZoom.isActive) {
+        const canvasPosition = panZoom.screenToCanvas(clientX, clientY);
+        x = canvasPosition.x;
+        y = canvasPosition.y;
+        effectiveWidth = mapWrapper.getBoundingClientRect().width || 1000;
+      } else {
+        const rect = theImage.getBoundingClientRect();
+        x = clientX - rect.left;
+        y = clientY - rect.top;
+        effectiveWidth = rect.width || 1000;
+      }
+
+      const cellSize = effectiveWidth / GRID_DIMENSION || 10;
+      const col = Math.min(Math.max(Math.floor(x / cellSize), 0), GRID_DIMENSION - 1);
+      const row = Math.min(Math.max(Math.floor(y / cellSize), 0), GRID_DIMENSION - 1);
+      return col + row * GRID_DIMENSION + 1;
+    }
+
+    function wasTouchTap(event) {
+      if (touchStartX === null || touchStartY === null || !touchStartAt) {
+        return false;
+      }
+
+      if (!event || !event.changedTouches || !event.changedTouches[0]) {
+        return false;
+      }
+
+      const touch = event.changedTouches[0];
+      const dx = touch.clientX - touchStartX;
+      const dy = touch.clientY - touchStartY;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      const duration = Date.now() - touchStartAt;
+
+      return distance <= TAP_MOVE_TOLERANCE_PX && duration <= TAP_MAX_DURATION_MS;
+    }
+
+    function clearTouchTapTracking() {
+      touchStartX = null;
+      touchStartY = null;
+      touchStartAt = 0;
+      touchTapReady = false;
+    }
+
+    function activateSelectedSquare() {
+      const href = whereToGoAnchor.getAttribute("href");
+      if (!href) return;
+
+      const target = whereToGoAnchor.getAttribute("target") || "_self";
+      if (target === "_blank") {
+        window.open(href, "_blank", "noopener");
+        return;
+      }
+
+      window.location.assign(href);
     }
 
     const squarePersonalizationsPromise = fetch("/build/squarePersonalizations.json").then(response => response.json());
@@ -147,10 +269,11 @@ title: "Su Squares, cute squares you own and personalize"
       positionSquareNumber = squareNumber;
       const positionDiv = document.getElementById("position");
       const tooltipDiv = document.getElementById("tooltip");
-      const whereToGoAnchor = document.getElementById("wheretogo");
-      const { wrapper, cellSize } = getMapMetrics();
+      const { stage, cellSize } = getMapMetrics();
       const col = (squareNumber - 1) % GRID_DIMENSION;
       const row = Math.floor((squareNumber - 1) / GRID_DIMENSION);
+      const zoomScale = panZoom && panZoom.isActive ? panZoom.scale : 1;
+      const tooltipBaseScale = zoomScale > 0 ? 1 / zoomScale : 1;
 
       if (!squarePersonalizations[squareNumber - 1]) {
         document.getElementById("theImage").style.cursor = "pointer";
@@ -166,39 +289,109 @@ title: "Su Squares, cute squares you own and personalize"
         whereToGoAnchor.href = squarePersonalizations[squareNumber - 1][1];
       }
 
-      positionDiv.style.width = cellSize + "px";
-      positionDiv.style.height = cellSize + "px";
-      positionDiv.style.left = (col * cellSize) + "px";
-      positionDiv.style.top = (row * cellSize) + "px";
+      positionDiv.style.width = "1%";
+      positionDiv.style.height = "1%";
+      positionDiv.style.left = col + "%";
+      positionDiv.style.top = row + "%";
       positionDiv.style.display = "block";
 
+      tooltipDiv.style.setProperty("--map-tooltip-base-scale", String(tooltipBaseScale));
       tooltipDiv.style.display = "block";
-      const maxLeft = Math.max(0, wrapper.clientWidth - tooltipDiv.offsetWidth);
+      const visualTooltipWidth = tooltipDiv.offsetWidth * tooltipBaseScale;
+      const visualTooltipHeight = tooltipDiv.offsetHeight * tooltipBaseScale;
+      const maxLeft = Math.max(0, stage.clientWidth - visualTooltipWidth);
       const preferredLeft = col * cellSize;
       const preferredTop = row * cellSize + cellSize * 3;
-      const fallbackTop = row * cellSize - tooltipDiv.offsetHeight - cellSize;
+      const fallbackTop = row * cellSize - visualTooltipHeight - cellSize;
       tooltipDiv.style.left = Math.min(Math.max(preferredLeft, 0), maxLeft) + "px";
-      tooltipDiv.style.top = (preferredTop + tooltipDiv.offsetHeight <= wrapper.clientHeight
+      tooltipDiv.style.top = (preferredTop + visualTooltipHeight <= stage.clientHeight
         ? preferredTop
         : Math.max(0, fallbackTop)) + "px";
     }
 
     function setPositionFromPointer(clientX, clientY) {
-      const theImage = document.getElementById("theImage");
-      const rect = theImage.getBoundingClientRect();
-      const cellSize = rect.width / GRID_DIMENSION || 10;
-      const x = Math.min(Math.max(Math.floor((clientX - rect.left) / cellSize), 0), GRID_DIMENSION - 1);
-      const y = Math.min(Math.max(Math.floor((clientY - rect.top) / cellSize), 0), GRID_DIMENSION - 1);
-      const squareNumber = x + y * GRID_DIMENSION + 1;
+      const squareNumber = getSquareFromPoint(clientX, clientY);
       setPosition(squareNumber);
+      return squareNumber;
     }
 
-    document.getElementById("theImage").addEventListener("mousemove", (e) => {
+    theImage.addEventListener("mousemove", (e) => {
       setPositionFromPointer(e.clientX, e.clientY);
     });
 
-    document.getElementById("theImage").addEventListener("click", (e) => {
-      setPositionFromPointer(e.clientX, e.clientY);
+    whereToGoAnchor.addEventListener("touchstart", (event) => {
+      if (!isTouchBillboard || !event.touches || event.touches.length !== 1) {
+        touchStartX = null;
+        touchStartY = null;
+        touchStartAt = 0;
+        return;
+      }
+
+      touchStartX = event.touches[0].clientX;
+      touchStartY = event.touches[0].clientY;
+      touchStartAt = Date.now();
+    }, { passive: true });
+
+    whereToGoAnchor.addEventListener("touchend", (event) => {
+      if (!isTouchBillboard) return;
+
+      if (panZoom && panZoom.isActive && panZoom.hasPanned()) {
+        pendingTouchSquare = null;
+        pendingTouchAt = 0;
+        suppressClickUntil = Date.now() + SUPPRESS_CLICK_WINDOW_MS;
+        clearTouchTapTracking();
+        return;
+      }
+
+      if (!wasTouchTap(event)) {
+        pendingTouchSquare = null;
+        pendingTouchAt = 0;
+        suppressClickUntil = Date.now() + SUPPRESS_CLICK_WINDOW_MS;
+        clearTouchTapTracking();
+        return;
+      }
+
+      touchTapReady = true;
+    }, { passive: true });
+
+    whereToGoAnchor.addEventListener("touchcancel", () => {
+      pendingTouchSquare = null;
+      pendingTouchAt = 0;
+      clearTouchTapTracking();
+    }, { passive: true });
+
+    whereToGoAnchor.addEventListener("click", (event) => {
+      const squareNumber = typeof event.clientX === "number" && typeof event.clientY === "number"
+        ? setPositionFromPointer(event.clientX, event.clientY)
+        : positionSquareNumber;
+      const href = whereToGoAnchor.getAttribute("href");
+
+      if (Date.now() < suppressClickUntil) {
+        event.preventDefault();
+        return;
+      }
+
+      if (isTouchBillboard && touchTapReady) {
+        touchTapReady = false;
+        const now = Date.now();
+        const isSameSquare = pendingTouchSquare === squareNumber;
+        const isWithinWindow = now - pendingTouchAt < DOUBLE_TAP_WINDOW_MS;
+
+        if (!isSameSquare || !isWithinWindow) {
+          pendingTouchSquare = squareNumber;
+          pendingTouchAt = now;
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
+
+        pendingTouchSquare = null;
+        pendingTouchAt = 0;
+      }
+
+      if (!href) {
+        event.preventDefault();
+      }
     });
 
     window.addEventListener("resize", () => {
@@ -213,6 +406,7 @@ title: "Su Squares, cute squares you own and personalize"
         // Move up
         if (positionSquareNumber > GRID_DIMENSION) setPosition(positionSquareNumber - GRID_DIMENSION);
         e.preventDefault(); // Prevent scrolling
+<<<<<<< HEAD
       } else if (key === 'a' || key === 'arrowleft') {
         // Move left
         if (positionSquareNumber % GRID_DIMENSION !== 1) setPosition(positionSquareNumber - 1);
@@ -225,9 +419,8 @@ title: "Su Squares, cute squares you own and personalize"
         if (positionSquareNumber % GRID_DIMENSION !== 0) setPosition(positionSquareNumber + 1);
       } else if (key === 'enter') {
         // Trigger click for highlighted square
-        const whereToGoAnchor = document.getElementById("wheretogo");
-        if (whereToGoAnchor.href) {
-          whereToGoAnchor.click();
+        if (whereToGoAnchor.getAttribute("href")) {
+          activateSelectedSquare();
         }
       }
     });


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> Prerequisite for Rito's new Billboard Square interaction modal implementation covering #54 

Add touch-first panzoom behavior to the homepage billboard; only takes effect on touch devices.

Support pinch-to-zoom, pan after zooming, double-tap square activation on touch devices, and mobile hint/reset UI without rewriting the homepage billboard architecture.

Keep the selected square highlighted with a pulsing blue glow and make the tooltip move with the billboard while preserving a stable initial on-screen size at the moment it appears.

**Demo site that includes Billboard square modal interaction:** [susquares.ritovision.com](https://susquares.ritovision.com)

## Video demo
*Chrome mobile android depicting panzoom, reset zoom and Square modal interactions (future PR)*

https://github.com/user-attachments/assets/c9ce7364-07a5-4bb0-a102-cd1bf0667c04


> [!NOTE]
> For full context on why this is a prerequisite for the Billboard modal square interaction, including video demonstrations of the broken browser-zoom flow versus the contained panzoom flow, see my comment on #54.