### PR TITLE
Refactor duplicated site footer into _includes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,12 @@
+<footer>
+  <small>
+    No cookies. No analytics.
+    {% if include.show_homepage_image_notice %}
+    Not responsible for content of linked sites. Images shown on homepage are &copy; their respective owners. This image
+    refreshes <a target="_blank"
+      href="https://github.com/su-squares/tenthousandsu.com/actions/workflows/load-from-blockchain.yml">hourly</a>.
+    {% endif %}
+    To the extent possible under law, Su Entriken has waived all copyright and related or neighboring rights to the
+    TenThousandSu.com website. This work is published from the United States.
+  </small>
+</footer>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -21,11 +21,7 @@
       <h2>Claim your Square</h2>
       <p>➡️ Next, go to <a href="/">the homepage</a>, and click an available Square to claim it.</p>
   </article>
-  <footer>
-    <small>
-      No cookies. No analytics. To the extent possible under law, Su Entriken has waived all copyright and related or neighboring rights to the TenThousandSu.com website. This work is published from the United States.
-    </small>
-  </footer>
+  {% include footer.html %}
   <script>
     // Add anchors on DOMContentLoaded
     document.addEventListener('DOMContentLoaded', function(event) {

--- a/buy.html
+++ b/buy.html
@@ -51,12 +51,7 @@ description: "Own a piece of the original NFT collection. Mint a Su Square for 0
     </div>
   </article>
 
-  <footer>
-    <small>
-      No cookies. No analytics. To the extent possible under law, Su Entriken has waived all copyright and related or
-      neighboring rights to the TenThousandSu.com website. This work is published from the United States.
-    </small>
-  </footer>
+  {% include footer.html %}
 
   <script type="module">
     // Elements and state //////////////////////////////////////////////////////////////////////////////////////////////

--- a/index.html
+++ b/index.html
@@ -65,16 +65,7 @@ title: "Su Squares, cute squares you own and personalize"
     </section>
   </article>
 
-  <footer>
-    <small>
-      No cookies. No analytics. Not responsible for content of linked sites. Images shown on homepage are &copy; their
-      respective owners. This image refreshes <a target="_blank"
-        href="https://github.com/su-squares/tenthousandsu.com/actions/workflows/load-from-blockchain.yml">hourly</a>. To
-      the extent possible under law, Su Entriken has waived
-      all copyright and related or neighboring rights to the TenThousandSu.com website. This work is published from the
-      United States.
-    </small>
-  </footer>
+  {% include footer.html show_homepage_image_notice=true %}
   <script>
     let positionSquareNumber = 1;
     var squarePersonalizations = [];

--- a/personalize-batch.html
+++ b/personalize-batch.html
@@ -94,12 +94,7 @@ description: "Personalize multiple Su Squares at once."
     </div>
   </article>
 
-  <footer>
-    <small>
-      No cookies. No analytics. To the extent possible under law, Su Entriken has waived all copyright and related or
-      neighboring rights to the TenThousandSu.com website. This work is published from the United States.
-    </small>
-  </footer>
+  {% include footer.html show_homepage_image_notice=true %}
 
   <script type="module">
     // Elements and state //////////////////////////////////////////////////////////////////////////////////////////////

--- a/personalize.html
+++ b/personalize.html
@@ -77,12 +77,7 @@ description: "Add your title and link to your Su Square. Make it yours."
     </div>
   </article>
 
-  <footer>
-    <small>
-      No cookies. No analytics. To the extent possible under law, Su Entriken has waived all copyright and related or
-      neighboring rights to the TenThousandSu.com website. This work is published from the United States.
-    </small>
-  </footer>
+  {% include footer.html show_homepage_image_notice=true %}
 
   <script type="module">
     // Elements and state //////////////////////////////////////////////////////////////////////////////////////////////

--- a/square.html
+++ b/square.html
@@ -64,16 +64,7 @@ title: "Su Squares, cute squares you own and personalize"
     <button class="btn" id="copy-emojified">Copy</button>
   </article>
 
-  <footer>
-    <small>
-      No cookies. No analytics. Not responsible for content of linked sites. Images shown on homepage are &copy; their
-      respective owners. This image <a target="_blank"
-        href="https://github.com/su-squares/tenthousandsu.com/actions/workflows/load-from-blockchain.yml">refreshes
-        hourly</a>. To the extent possible under law, Su Entriken has waived
-      all copyright and related or neighboring rights to the TenThousandSu.com website. This work is published from the
-      United States.
-    </small>
-  </footer>
+  {% include footer.html show_homepage_image_notice=true %}
   <script>
     // Get URL fragment
     const squareNumber = parseInt(window.location.hash.substring(1));


### PR DESCRIPTION
## Description
Makes duplicative footer markup DRY by extracting it into a reusable Jekyll `_includes` component.

Creates a variant for the hourly image update disclaimer, and applies it to both personalization pages since that information is relevant to users expecting to see their Squares change after use.
